### PR TITLE
fixing GetFrameworkName for MonoAndroid

### DIFF
--- a/dnSpy/Files/TreeView/ExeUtils.cs
+++ b/dnSpy/Files/TreeView/ExeUtils.cs
@@ -167,7 +167,10 @@ namespace dnSpy.Files.TreeView {
 			case "Silverlight":
 				return "Silverlight " + versionString;
 
-			default:
+            case "MonoAndroid":
+                return "Mono Android" + versionString;
+
+            default:
 				Debug.Fail("Unknown target framework: " + id);
 				if (id.Length > 20)
 					return null;

--- a/dnSpy/Files/TreeView/ExeUtils.cs
+++ b/dnSpy/Files/TreeView/ExeUtils.cs
@@ -168,7 +168,7 @@ namespace dnSpy.Files.TreeView {
 				return "Silverlight " + versionString;
 
             case "MonoAndroid":
-                return "Mono Android" + versionString;
+                return "Mono Android " + versionString;
 
             default:
 				Debug.Fail("Unknown target framework: " + id);


### PR DESCRIPTION
just a small fix to prevent that Debug.Fail in a current target, which uses MonoAndroid