### PR TITLE
Open AboutScreen in new Tab

### DIFF
--- a/dnSpy/MainApp/AboutScreen.cs
+++ b/dnSpy/MainApp/AboutScreen.cs
@@ -83,7 +83,7 @@ namespace dnSpy.MainApp {
 		}
 
 		public override void Execute(IMenuItemContext context) {
-			var tab = fileTabManager.GetOrCreateActiveTab();
+			var tab = fileTabManager.OpenEmptyTab();
 			tab.Show(new AboutScreenFileTabContent(appWindow, pluginManager), null, null);
 			fileTabManager.SetFocus(tab);
 		}


### PR DESCRIPTION
With this small commit the AboutScreen opens in a new tab instead of overwriting the current active tab.