### PR TITLE
Made some AsmEditor undo redo objects public

### DIFF
--- a/Extensions/dnSpy.AsmEditor/UndoRedo/IUndoCommand.cs
+++ b/Extensions/dnSpy.AsmEditor/UndoRedo/IUndoCommand.cs
@@ -23,7 +23,7 @@ namespace dnSpy.AsmEditor.UndoRedo {
 	/// <summary>
 	/// An assembly editor command that can be undone. Dispose() is called when the history is cleared.
 	/// </summary>
-	interface IUndoCommand {
+	public interface IUndoCommand {
 		/// <summary>
 		/// Gets a description of the command
 		/// </summary>

--- a/Extensions/dnSpy.AsmEditor/UndoRedo/IUndoObject.cs
+++ b/Extensions/dnSpy.AsmEditor/UndoRedo/IUndoObject.cs
@@ -18,7 +18,7 @@
 */
 
 namespace dnSpy.AsmEditor.UndoRedo {
-	interface IUndoObject {
+	public interface IUndoObject {
 		bool IsDirty { get; set; }
 		int SavedCommand { get; set; }
 	}

--- a/Extensions/dnSpy.AsmEditor/UndoRedo/IUndoableDocumentsProvider.cs
+++ b/Extensions/dnSpy.AsmEditor/UndoRedo/IUndoableDocumentsProvider.cs
@@ -20,7 +20,7 @@
 using System.Collections.Generic;
 
 namespace dnSpy.AsmEditor.UndoRedo {
-	interface IUndoableDocumentsProvider {
+	public interface IUndoableDocumentsProvider {
 		IEnumerable<IUndoObject> GetObjects();
 		IUndoObject GetUndoObject(object obj);
 		bool OnExecutedOneCommand(IUndoObject obj);

--- a/Extensions/dnSpy.AsmEditor/UndoRedo/UndoCommandManager.cs
+++ b/Extensions/dnSpy.AsmEditor/UndoRedo/UndoCommandManager.cs
@@ -26,7 +26,7 @@ using System.Windows.Input;
 using System.Windows.Threading;
 
 namespace dnSpy.AsmEditor.UndoRedo {
-	interface IUndoCommandManager {
+	public interface IUndoCommandManager {
 		/// <summary>
 		/// true if we can undo a command group
 		/// </summary>

--- a/Extensions/dnSpy.AsmEditor/UndoRedo/UndoCommandManagerEventArgs.cs
+++ b/Extensions/dnSpy.AsmEditor/UndoRedo/UndoCommandManagerEventArgs.cs
@@ -20,7 +20,7 @@
 using System;
 
 namespace dnSpy.AsmEditor.UndoRedo {
-	enum UndoCommandManagerEventType {
+	public enum UndoCommandManagerEventType {
 		Add,
 		Undo,
 		Redo,
@@ -30,7 +30,7 @@ namespace dnSpy.AsmEditor.UndoRedo {
 		Dirty,
 	}
 
-	sealed class UndoCommandManagerEventArgs : EventArgs {
+	public sealed class UndoCommandManagerEventArgs : EventArgs {
 		public readonly UndoCommandManagerEventType Type;
 		public readonly IUndoObject UndoObject;
 


### PR DESCRIPTION
I need AsmEditor Undo Redo and Save Module features for extension I'm making. By exposing Undo Redo manager I can undo and redo my actions with addition to save modules with my changes.

Another alternative would be to move some Undo Redo logic to Contracts