### PR TITLE
Change IsVisible to IsEnabled

### DIFF
--- a/Extensions/dnSpy.AsmEditor/Commands/CloseOldInMemoryModulesCommand.cs
+++ b/Extensions/dnSpy.AsmEditor/Commands/CloseOldInMemoryModulesCommand.cs
@@ -54,7 +54,7 @@ namespace dnSpy.AsmEditor.Commands {
 			return nodes.Count == 0 ? null : nodes.ToArray();
 		}
 
-		public override bool IsVisible(IMenuItemContext context) => GetNodes() != null;
+		public override bool IsEnabled(IMenuItemContext context) => GetNodes() != null;
 		public override void Execute(IMenuItemContext context) {
 			var nodes = GetNodes();
 			if (nodes != null)


### PR DESCRIPTION
It is better to show command as disabled, instead of hiding it completely. (at least according to UX)
I was searching for this command and wasn't able to find it until I debugged something in memory.