### PR TITLE
#311 Inconsistent dialog questions

### DIFF
--- a/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.Designer.cs
+++ b/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.Designer.cs
@@ -197,7 +197,7 @@ namespace dnSpy.AsmEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is an unsaved file. Are you sure you want to exit?.
+        ///   Looks up a localized string similar to There is an unsaved file. Do you want to save it before exiting?.
         /// </summary>
         public static string AskExitUnsavedFile {
             get {
@@ -206,7 +206,7 @@ namespace dnSpy.AsmEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There are {0} unsaved files. Are you sure you want to exit?.
+        ///   Looks up a localized string similar to There are {0} unsaved files. Do you want to save them before exiting?.
         /// </summary>
         public static string AskExitUnsavedFiles {
             get {

--- a/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.resx
+++ b/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.resx
@@ -1035,10 +1035,10 @@ Are you sure you want to close the window?</value>
     <value>There could be code in some assembly that references this type. Are you sure you want to delete the type?</value>
   </data>
   <data name="AskExitUnsavedFile" xml:space="preserve">
-    <value>There is an unsaved file. Are you sure you want to exit?</value>
+    <value>There is an unsaved file. Do you want to save it before exiting?</value>
   </data>
   <data name="AskExitUnsavedFiles" xml:space="preserve">
-    <value>There are {0} unsaved files. Are you sure you want to exit?</value>
+    <value>There are {0} unsaved files. Do you want to save them before exiting?</value>
   </data>
   <data name="AskLoadAssembliesLoseChanges" xml:space="preserve">
     <value>Are you sure you want to load new assemblies and lose all changes?</value>

--- a/Extensions/dnSpy.AsmEditor/SaveModule/DocumentSaver.cs
+++ b/Extensions/dnSpy.AsmEditor/SaveModule/DocumentSaver.cs
@@ -67,6 +67,8 @@ namespace dnSpy.AsmEditor.SaveModule {
 
 			var msg = modifiedDocs.Length == 1 ? dnSpy_AsmEditor_Resources.AskSaveFile : dnSpy_AsmEditor_Resources.AskSaveFiles;
 			var res = MsgBox.Instance.Show(msg, MsgBoxButton.Yes | MsgBoxButton.No);
+            if (res == MsgBoxButton.None)
+                return false;
 			if (res == MsgBoxButton.No)
 				return true;
 			return Save(modifiedDocs);

--- a/Extensions/dnSpy.AsmEditor/SaveModule/DocumentSaver.cs
+++ b/Extensions/dnSpy.AsmEditor/SaveModule/DocumentSaver.cs
@@ -67,8 +67,8 @@ namespace dnSpy.AsmEditor.SaveModule {
 
 			var msg = modifiedDocs.Length == 1 ? dnSpy_AsmEditor_Resources.AskSaveFile : dnSpy_AsmEditor_Resources.AskSaveFiles;
 			var res = MsgBox.Instance.Show(msg, MsgBoxButton.Yes | MsgBoxButton.No);
-            if (res == MsgBoxButton.None)
-                return false;
+			if (res == MsgBoxButton.None)
+				return false;
 			if (res == MsgBoxButton.No)
 				return true;
 			return Save(modifiedDocs);

--- a/Extensions/dnSpy.AsmEditor/UndoRedo/Commands.cs
+++ b/Extensions/dnSpy.AsmEditor/UndoRedo/Commands.cs
@@ -31,15 +31,13 @@ namespace dnSpy.AsmEditor.UndoRedo {
 	sealed class UndoRedoCommmandLoader : IAutoLoaded {
 		readonly Lazy<IUndoCommandService> undoCommandService;
 		readonly IMessageBoxService messageBoxService;
-        readonly Lazy<IDocumentSaver> documentSaver;
-        readonly IAppWindow appWindow;
+		readonly Lazy<IDocumentSaver> documentSaver;
 
-        [ImportingConstructor]
+		[ImportingConstructor]
 		UndoRedoCommmandLoader(IWpfCommandService wpfCommandService, Lazy<IUndoCommandService> undoCommandService, IAppWindow appWindow, IMessageBoxService messageBoxService, Lazy<IDocumentSaver> documentSaver) {
-            this.appWindow = appWindow;
-            this.undoCommandService = undoCommandService;
+			this.undoCommandService = undoCommandService;
 			this.messageBoxService = messageBoxService;
-            this.documentSaver = documentSaver;
+			this.documentSaver = documentSaver;
 
 			var cmds = wpfCommandService.GetCommands(ControlConstants.GUID_MAINWINDOW);
 			cmds.Add(UndoRoutedCommands.Undo, (s, e) => undoCommandService.Value.Undo(), (s, e) => e.CanExecute = undoCommandService.Value.CanUndo);

--- a/Extensions/dnSpy.AsmEditor/UndoRedo/Commands.cs
+++ b/Extensions/dnSpy.AsmEditor/UndoRedo/Commands.cs
@@ -24,17 +24,22 @@ using dnSpy.AsmEditor.Properties;
 using dnSpy.Contracts.App;
 using dnSpy.Contracts.Controls;
 using dnSpy.Contracts.Extension;
+using dnSpy.AsmEditor.SaveModule;
 
 namespace dnSpy.AsmEditor.UndoRedo {
 	[ExportAutoLoaded]
 	sealed class UndoRedoCommmandLoader : IAutoLoaded {
 		readonly Lazy<IUndoCommandService> undoCommandService;
 		readonly IMessageBoxService messageBoxService;
+        readonly Lazy<IDocumentSaver> documentSaver;
+        readonly IAppWindow appWindow;
 
-		[ImportingConstructor]
-		UndoRedoCommmandLoader(IWpfCommandService wpfCommandService, Lazy<IUndoCommandService> undoCommandService, IAppWindow appWindow, IMessageBoxService messageBoxService) {
-			this.undoCommandService = undoCommandService;
+        [ImportingConstructor]
+		UndoRedoCommmandLoader(IWpfCommandService wpfCommandService, Lazy<IUndoCommandService> undoCommandService, IAppWindow appWindow, IMessageBoxService messageBoxService, Lazy<IDocumentSaver> documentSaver) {
+            this.appWindow = appWindow;
+            this.undoCommandService = undoCommandService;
 			this.messageBoxService = messageBoxService;
+            this.documentSaver = documentSaver;
 
 			var cmds = wpfCommandService.GetCommands(ControlConstants.GUID_MAINWINDOW);
 			cmds.Add(UndoRoutedCommands.Undo, (s, e) => undoCommandService.Value.Undo(), (s, e) => e.CanExecute = undoCommandService.Value.CanUndo);
@@ -47,11 +52,15 @@ namespace dnSpy.AsmEditor.UndoRedo {
 			var count = undoCommandService.Value.NumberOfModifiedDocuments;
 			if (count == 0)
 				return;
-
 			var msg = count == 1 ? dnSpy_AsmEditor_Resources.AskExitUnsavedFile :
 					string.Format(dnSpy_AsmEditor_Resources.AskExitUnsavedFiles, count);
 			var res = messageBoxService.Show(msg, MsgBoxButton.Yes | MsgBoxButton.No);
-			if (res == MsgBoxButton.No || res == MsgBoxButton.None)
+            if (res == MsgBoxButton.Yes) {
+                appWindow.MainWindow.Hide();
+                documentSaver.Value.Save(undoCommandService.Value.GetModifiedDocuments());
+            }
+
+            if (res == MsgBoxButton.None)
 				e.Cancel = true;
 		}
 	}

--- a/Extensions/dnSpy.AsmEditor/UndoRedo/Commands.cs
+++ b/Extensions/dnSpy.AsmEditor/UndoRedo/Commands.cs
@@ -55,12 +55,10 @@ namespace dnSpy.AsmEditor.UndoRedo {
 			var msg = count == 1 ? dnSpy_AsmEditor_Resources.AskExitUnsavedFile :
 					string.Format(dnSpy_AsmEditor_Resources.AskExitUnsavedFiles, count);
 			var res = messageBoxService.Show(msg, MsgBoxButton.Yes | MsgBoxButton.No);
-            if (res == MsgBoxButton.Yes) {
-                appWindow.MainWindow.Hide();
-                documentSaver.Value.Save(undoCommandService.Value.GetModifiedDocuments());
-            }
+			if (res == MsgBoxButton.Yes)
+				documentSaver.Value.Save(undoCommandService.Value.GetModifiedDocuments());
 
-            if (res == MsgBoxButton.None)
+			if (res == MsgBoxButton.None)
 				e.Cancel = true;
 		}
 	}


### PR DESCRIPTION
- Buttons in a save dialog for assembly list and application close refer to the same actions now.
- Dialog message (on application close) was modified.