### PR TITLE
NullReferenceException closing document if ShowBlockStucture is disabled.

### DIFF
--- a/dnSpy/dnSpy/Text/Editor/BlockStructureService.cs
+++ b/dnSpy/dnSpy/Text/Editor/BlockStructureService.cs
@@ -559,9 +559,9 @@ done:
 
 		void UnregisterEvents() {
 			wpfTextView.LayoutChanged -= WpfTextView_LayoutChanged;
-			//if (editorFormatMap != null) { 
+			if (editorFormatMap != null) { 
 				editorFormatMap.FormatMappingChanged -= EditorFormatMap_FormatMappingChanged;
-			//}
+			}
 		}
 
 		void WpfTextView_Closed(object sender, EventArgs e) {

--- a/dnSpy/dnSpy/Text/Editor/BlockStructureService.cs
+++ b/dnSpy/dnSpy/Text/Editor/BlockStructureService.cs
@@ -559,7 +559,9 @@ done:
 
 		void UnregisterEvents() {
 			wpfTextView.LayoutChanged -= WpfTextView_LayoutChanged;
-			editorFormatMap.FormatMappingChanged -= EditorFormatMap_FormatMappingChanged;
+			//if (editorFormatMap != null) { 
+				editorFormatMap.FormatMappingChanged -= EditorFormatMap_FormatMappingChanged;
+			//}
 		}
 
 		void WpfTextView_Closed(object sender, EventArgs e) {


### PR DESCRIPTION
Added null check before unsubscribing from editorFormatMap since this
field will be null if ShowBlockStructure is not enabled.