### PR TITLE
Make UsedBy return all occurances

### DIFF
--- a/Extensions/dnSpy.Analyzer/TreeNodes/VirtualMethodUsedByNode.cs
+++ b/Extensions/dnSpy.Analyzer/TreeNodes/VirtualMethodUsedByNode.cs
@@ -89,7 +89,7 @@ namespace dnSpy.Analyzer.TreeNodes {
 					IMethod mr = instr.Operand as IMethod;
 					if (mr != null && !mr.IsField && mr.Name == name) {
 						// explicit call to the requested method 
-						if (instr.OpCode.Code == Code.Call
+						if ((instr.OpCode.Code == Code.Call || instr.OpCode.Code == Code.Callvirt)
 							&& Helpers.IsReferencedBy(analyzedMethod.DeclaringType, mr.DeclaringType)
 							&& mr.ResolveMethodDef() == analyzedMethod) {
 							foundInstr = instr;


### PR DESCRIPTION
Non-virtual methods can be called either with OpCode CALL or CALLVIRT. See https://stackoverflow.com/a/193952/3351794 for motivation.

Fixes #509