### PR TITLE
Keep focus when editing TreeViewItem (fixes #554)

### DIFF
--- a/Extensions/dnSpy.AsmEditor/Assembly/AssemblyCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Assembly/AssemblyCommands.cs
@@ -291,6 +291,8 @@ namespace dnSpy.AsmEditor.Assembly {
 				return;
 
 			undoCommandService.Value.Add(new AssemblySettingsCommand(asmNode, data.CreateAssemblyOptions()));
+
+			asmNode.TreeNode.TreeView.SelectItems(new[] { asmNode });
 		}
 
 		readonly AssemblyDocumentNode asmNode;

--- a/Extensions/dnSpy.AsmEditor/Event/EventDefCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Event/EventDefCommands.cs
@@ -383,6 +383,8 @@ namespace dnSpy.AsmEditor.Event {
 				return;
 
 			undoCommandService.Value.Add(new EventDefSettingsCommand(eventNode, data.CreateEventDefOptions()));
+
+			eventNode.TreeNode.TreeView.SelectItems(new[] { eventNode });
 		}
 
 		readonly EventNode eventNode;

--- a/Extensions/dnSpy.AsmEditor/Field/FieldDefCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Field/FieldDefCommands.cs
@@ -390,6 +390,8 @@ namespace dnSpy.AsmEditor.Field {
 				return;
 
 			undoCommandService.Value.Add(new FieldDefSettingsCommand(fieldNode, data.CreateFieldDefOptions()));
+
+			fieldNode.TreeNode.TreeView.SelectItems(new[] { fieldNode });
 		}
 
 		readonly FieldNode fieldNode;

--- a/Extensions/dnSpy.AsmEditor/Method/MethodDefCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Method/MethodDefCommands.cs
@@ -478,6 +478,8 @@ namespace dnSpy.AsmEditor.Method {
 				return;
 
 			undoCommandService.Value.Add(new MethodDefSettingsCommand(methodNode, data.CreateMethodDefOptions()));
+
+			methodNode.TreeNode.TreeView.SelectItems(new[] { methodNode });
 		}
 
 		readonly MethodNode methodNode;

--- a/Extensions/dnSpy.AsmEditor/Module/ModuleCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Module/ModuleCommands.cs
@@ -749,6 +749,8 @@ namespace dnSpy.AsmEditor.Module {
 				return;
 
 			undoCommandService.Value.Add(new ModuleSettingsCommand(asmNode, data.CreateModuleOptions()));
+
+			asmNode.TreeNode.TreeView.SelectItems(new[] { asmNode });
 		}
 
 		readonly ModuleDocumentNode modNode;

--- a/Extensions/dnSpy.AsmEditor/Namespace/NamespaceCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Namespace/NamespaceCommands.cs
@@ -382,6 +382,8 @@ namespace dnSpy.AsmEditor.Namespace {
 				return;
 
 			undoCommandService.Value.Add(new RenameNamespaceCommand(data.Name, nsNode));
+
+			nsNode.TreeNode.TreeView.SelectItems(new[] { nsNode });
 		}
 
 		readonly string newName;

--- a/Extensions/dnSpy.AsmEditor/Property/PropertyDefCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Property/PropertyDefCommands.cs
@@ -380,6 +380,8 @@ namespace dnSpy.AsmEditor.Property {
 				return;
 
 			undoCommandService.Value.Add(new PropertyDefSettingsCommand(propNode, data.CreatePropertyDefOptions()));
+
+			propNode.TreeNode.TreeView.SelectItems(new[] { propNode });
 		}
 
 		readonly PropertyNode propNode;

--- a/Extensions/dnSpy.AsmEditor/Resources/ResourceCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Resources/ResourceCommands.cs
@@ -1043,6 +1043,8 @@ namespace dnSpy.AsmEditor.Resources {
 				return;
 
 			undoCommandService.Value.Add(new ResourceSettingsCommand(rsrcNode, data.CreateResourceOptions()));
+
+			rsrcNode.TreeNode.TreeView.SelectItems(new[] { rsrcNode });
 		}
 
 		readonly ResourceNode rsrcNode;

--- a/Extensions/dnSpy.AsmEditor/Types/TypeDefCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Types/TypeDefCommands.cs
@@ -475,6 +475,8 @@ namespace dnSpy.AsmEditor.Types {
 				return;
 
 			undoCommandService.Value.Add(new TypeDefSettingsCommand(module, typeNode, data.CreateTypeDefOptions()));
+
+			typeNode.TreeNode.TreeView.SelectItems(new[] { typeNode });
 		}
 
 		readonly ModuleDef module;


### PR DESCRIPTION
I added `someNode.TreeNode.TreeView.SelectItems(new[] { someNode });` to the end of all `Execute` methods of `SomeSettingsCommand` classes to reset focus back to the modified TreeNode. 

So far this only covers active editing, not undo/redo. I will commit that in a minute.