### PR TITLE
Illegal path fix

### DIFF
--- a/dnSpy/dnSpy/Documents/DotNetCorePaths.cs
+++ b/dnSpy/dnSpy/Documents/DotNetCorePaths.cs
@@ -94,7 +94,8 @@ namespace dnSpy.Documents {
 		const string DotNetExeName = "dotnet.exe";
 		static IEnumerable<(string path, int bitness)> GetDotNetCoreBaseDirs() {
 			var pathEnvVar = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-			foreach (var path in pathEnvVar.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+			foreach (var origPath in pathEnvVar.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+				var path = origPath.Trim();
 				if (!Directory.Exists(path))
 					continue;
 				string file;


### PR DESCRIPTION
This patch can prevent crashing with illegal chars in path variable.
Concretely spaces after dotnet.exe directory ("...;[dotnetdir] ;...")