### PR TITLE
Follow shortcuts on drag&drop

### DIFF
--- a/dnSpy/dnSpy/Documents/TreeView/DocumentTreeView.cs
+++ b/dnSpy/dnSpy/Documents/TreeView/DocumentTreeView.cs
@@ -752,6 +752,22 @@ namespace dnSpy.Documents.TreeView {
 			filenames = filenames.Where(a => File.Exists(a) && !existingFiles.Contains(a)).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(a => Path.GetFileNameWithoutExtension(a), StringComparer.CurrentCultureIgnoreCase).ToArray();
 			TreeNodeData newSelectedNode = null;
 			for (int i = 0, j = 0; i < filenames.Length; i++) {
+				// Resolve shortcuts
+				string directory = Path.GetDirectoryName(filenames[i]);
+				string file = Path.GetFileName(filenames[i]);
+
+				Shell32.Shell shell = new Shell32.Shell();
+				Shell32.Folder folder = shell.NameSpace(directory);
+				Shell32.FolderItem folderItem = folder.ParseName(file);
+
+				if (folderItem != null) {
+					if (folderItem.IsLink) {
+						Shell32.ShellLinkObject link = (Shell32.ShellLinkObject)folderItem.GetLink;
+						filenames[i] = link.Path;
+					}
+				}
+
+
 				var document = DocumentService.TryCreateOnly(DsDocumentInfo.CreateDocument(filenames[i]));
 				if (document == null)
 					continue;

--- a/dnSpy/dnSpy/dnSpy.csproj
+++ b/dnSpy/dnSpy/dnSpy.csproj
@@ -59,6 +59,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="PresentationFramework.Aero" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -1405,5 +1406,16 @@
       <Visible>false</Visible>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="Shell32">
+      <Guid>{50A7E9B0-70EF-11D1-B75A-00A0C90564FE}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi,
at the moment `*.lnk` files are added to the assembly list as they are if you drag and drop them to the list. You just can hex edit them which makes no sense to me. Adding them by the open dialog will follow links. With this patch links will be resolved by drag and drop too.