### PR TITLE
Persist Allow Field Initializers setting across sessions

### DIFF
--- a/Extensions/ILSpy.Decompiler/dnSpy.Decompiler.ILSpy/Settings/DecompilerSettingsImpl.cs
+++ b/Extensions/ILSpy.Decompiler/dnSpy.Decompiler.ILSpy/Settings/DecompilerSettingsImpl.cs
@@ -69,7 +69,7 @@ namespace dnSpy.Decompiler.ILSpy.Settings {
 			//this.MaxArrayElements = sect.Attribute<int?>(nameof(MaxArrayElements)) ?? this.MaxArrayElements;
 			SortCustomAttributes = sect.Attribute<bool?>(nameof(SortCustomAttributes)) ?? SortCustomAttributes;
 			UseSourceCodeOrder = sect.Attribute<bool?>(nameof(UseSourceCodeOrder)) ?? UseSourceCodeOrder;
-			//this.AllowFieldInitializers = sect.Attribute<bool?>(nameof(AllowFieldInitializers)) ?? this.AllowFieldInitializers;
+			AllowFieldInitializers = sect.Attribute<bool?>(nameof(AllowFieldInitializers)) ?? this.AllowFieldInitializers;
 			OneCustomAttributePerLine = sect.Attribute<bool?>(nameof(OneCustomAttributePerLine)) ?? OneCustomAttributePerLine;
 			TypeAddInternalModifier = sect.Attribute<bool?>(nameof(TypeAddInternalModifier)) ?? TypeAddInternalModifier;
 			MemberAddPrivateModifier = sect.Attribute<bool?>(nameof(MemberAddPrivateModifier)) ?? MemberAddPrivateModifier;
@@ -118,7 +118,7 @@ namespace dnSpy.Decompiler.ILSpy.Settings {
 			//sect.Attribute(nameof(MaxArrayElements), MaxArrayElements);
 			sect.Attribute(nameof(SortCustomAttributes), SortCustomAttributes);
 			sect.Attribute(nameof(UseSourceCodeOrder), UseSourceCodeOrder);
-			//sect.Attribute(nameof(AllowFieldInitializers), AllowFieldInitializers);
+			sect.Attribute(nameof(AllowFieldInitializers), AllowFieldInitializers);
 			sect.Attribute(nameof(OneCustomAttributePerLine), OneCustomAttributePerLine);
 			sect.Attribute(nameof(TypeAddInternalModifier), TypeAddInternalModifier);
 			sect.Attribute(nameof(MemberAddPrivateModifier), MemberAddPrivateModifier);


### PR DESCRIPTION
Fixes the issue referenced in #967