### PR TITLE
Add replace with NOPs to AsmEditor

### DIFF
--- a/Extensions/dnSpy.AsmEditor/MethodBody/CilBodyVM.cs
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/CilBodyVM.cs
@@ -326,6 +326,7 @@ namespace dnSpy.AsmEditor.MethodBody {
 				// Speed optimization, see comment in SimplifyAllInstructions()
 				UninstallInstructionHandlers(instrs);
 
+				Array.Sort(instrs, (a, b) => b.Index - a.Index);
 				foreach (var instr in instrs) {
 					var size = instr.GetSize();
 					for (int i = 1; i < size; i++)

--- a/Extensions/dnSpy.AsmEditor/MethodBody/CilBodyVM.cs
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/CilBodyVM.cs
@@ -44,6 +44,7 @@ namespace dnSpy.AsmEditor.MethodBody {
 		public ICommand SimplifyAllInstructionsCommand => new RelayCommand(a => SimplifyAllInstructions(), a => SimplifyAllInstructionsCanExecute());
 		public ICommand OptimizeAllInstructionsCommand => new RelayCommand(a => OptimizeAllInstructions(), a => OptimizeAllInstructionsCanExecute());
 		public ICommand ReplaceInstructionWithNopCommand => new RelayCommand(a => ReplaceInstructionWithNop((InstructionVM[])a), a => ReplaceInstructionWithNopCanExecute((InstructionVM[])a));
+		public ICommand ReplaceInstructionWithMultipleNopsCommand => new RelayCommand(a => ReplaceInstructionWithMultipleNops((InstructionVM[])a), a => ReplaceInstructionWithMultipleNopsCanExecute((InstructionVM[])a));
 		public ICommand InvertBranchCommand => new RelayCommand(a => InvertBranch((InstructionVM[])a), a => InvertBranchCanExecute((InstructionVM[])a));
 		public ICommand ConvertBranchToUnconditionalBranchCommand => new RelayCommand(a => ConvertBranchToUnconditionalBranch((InstructionVM[])a), a => ConvertBranchToUnconditionalBranchCanExecute((InstructionVM[])a));
 		public ICommand RemoveInstructionAndAddPopsCommand => new RelayCommand(a => RemoveInstructionAndAddPops((InstructionVM[])a), a => RemoveInstructionAndAddPopsCanExecute((InstructionVM[])a));
@@ -315,6 +316,32 @@ namespace dnSpy.AsmEditor.MethodBody {
 		}
 
 		bool ReplaceInstructionWithNopCanExecute(InstructionVM[] instrs) => instrs.Any(a => a.Code != Code.Nop);
+
+		void ReplaceInstructionWithMultipleNops(InstructionVM[] instrs) {
+			var old1 = InstructionsListVM.DisableAutoUpdateProps;
+			var old2 = DisableHasError();
+			try {
+				InstructionsListVM.DisableAutoUpdateProps = true;
+
+				// Speed optimization, see comment in SimplifyAllInstructions()
+				UninstallInstructionHandlers(instrs);
+
+				foreach (var instr in instrs) {
+					var size = instr.GetSize();
+					for (int i = 1; i < size; i++)
+						InstructionsListVM.Insert(instr.Index + i, CreateInstructionVM(Code.Nop));
+					instr.Code = Code.Nop;
+				}
+			}
+			finally {
+				InstallInstructionHandlers(instrs);
+				RestoreHasError(old2);
+				InstructionsListVM.DisableAutoUpdateProps = old1;
+			}
+			InstructionsUpdateIndexes(0);
+		}
+
+		bool ReplaceInstructionWithMultipleNopsCanExecute(InstructionVM[] instrs) => instrs.Any(a => a.Code != Code.Nop);
 
 		void InvertBranch(InstructionVM[] instrs) {
 			foreach (var instr in instrs) {

--- a/Extensions/dnSpy.AsmEditor/MethodBody/InstructionsListHelper.cs
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/InstructionsListHelper.cs
@@ -73,6 +73,15 @@ namespace dnSpy.AsmEditor.MethodBody {
 				Key = Key.N,
 			});
 			Add(new ContextMenuHandler {
+				Header = "res:ReplaceNopsInstrCommand",
+				HeaderPlural = "res:ReplaceNopsInstrsCommand",
+				Command = cilBodyVM.ReplaceInstructionWithMultipleNopsCommand,
+				Icon = null,
+				InputGestureText = "res:ShortCutKeyR",
+				Modifiers = ModifierKeys.None,
+				Key = Key.R,
+			});
+			Add(new ContextMenuHandler {
 				Header = "res:InvertBranchCommand",
 				HeaderPlural = "res:InvertBranchesCommand",
 				Command = cilBodyVM.InvertBranchCommand,

--- a/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.Designer.cs
+++ b/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.Designer.cs
@@ -5453,6 +5453,24 @@ namespace dnSpy.AsmEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Replace with NOPs.
+        /// </summary>
+        public static string ReplaceNopsInstrCommand {
+            get {
+                return ResourceManager.GetString("ReplaceNopsInstrCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Replace with NOPs.
+        /// </summary>
+        public static string ReplaceNopsInstrsCommand {
+            get {
+                return ResourceManager.GetString("ReplaceNopsInstrsCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Run NGEN.exe if this assembly is installed in the GAC.
         /// </summary>
         public static string RerunNgenIfGacAssembly {

--- a/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.resx
+++ b/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.resx
@@ -1964,6 +1964,9 @@ Most options will be re-initialized when this checkbox is clicked</value>
   <data name="ShortCutKeyP" xml:space="preserve">
     <value>P</value>
   </data>
+  <data name="ShortCutKeyR" xml:space="preserve">
+    <value>R</value>
+  </data>
   <data name="ShortCutKeyS" xml:space="preserve">
     <value>S</value>
   </data>
@@ -2533,5 +2536,11 @@ Most options will be re-initialized when this checkbox is clicked</value>
   </data>
   <data name="CompilerDlgTabTitle" xml:space="preserve">
     <value>Compiler</value>
+  </data>
+  <data name="ReplaceNopsInstrCommand" xml:space="preserve">
+    <value>_Replace with NOPs</value>
+  </data>
+  <data name="ReplaceNopsInstrsCommand" xml:space="preserve">
+    <value>_Replace with NOPs</value>
   </data>
 </root>


### PR DESCRIPTION
This option replaces the given instructions with a number of NOPs equal to the size of each of those instructions, so that the code size remains the same.