### PR TITLE
FullyQualifiedAllTypes in UI

### DIFF
--- a/Extensions/ILSpy.Decompiler/dnSpy.Decompiler.ILSpy/Settings/DecompilerSettingsImpl.cs
+++ b/Extensions/ILSpy.Decompiler/dnSpy.Decompiler.ILSpy/Settings/DecompilerSettingsImpl.cs
@@ -53,8 +53,8 @@ namespace dnSpy.Decompiler.ILSpy.Settings {
 			//SwitchStatementOnString = sect.Attribute<bool?>(nameof(SwitchStatementOnString)) ?? SwitchStatementOnString;
 			//UsingDeclarations = sect.Attribute<bool?>(nameof(UsingDeclarations)) ?? UsingDeclarations;
 			QueryExpressions = sect.Attribute<bool?>(nameof(QueryExpressions)) ?? QueryExpressions;
-			//FullyQualifyAmbiguousTypeNames = sect.Attribute<bool?>(nameof(FullyQualifyAmbiguousTypeNames)) ?? FullyQualifyAmbiguousTypeNames;
-			//FullyQualifyAllTypes = sect.Attribute<bool?>(nameof(FullyQualifyAllTypes)) ?? FullyQualifyAllTypes;
+			FullyQualifyAmbiguousTypeNames = sect.Attribute<bool?>(nameof(FullyQualifyAmbiguousTypeNames)) ?? FullyQualifyAmbiguousTypeNames;
+			FullyQualifyAllTypes = sect.Attribute<bool?>(nameof(FullyQualifyAllTypes)) ?? FullyQualifyAllTypes;
 			UseDebugSymbols = sect.Attribute<bool?>(nameof(UseDebugSymbols)) ?? UseDebugSymbols;
 			//ObjectOrCollectionInitializers = sect.Attribute<bool?>(nameof(ObjectOrCollectionInitializers)) ?? ObjectOrCollectionInitializers;
 			ShowXmlDocumentation = sect.Attribute<bool?>(nameof(ShowXmlDocumentation)) ?? ShowXmlDocumentation;
@@ -102,8 +102,8 @@ namespace dnSpy.Decompiler.ILSpy.Settings {
 			//sect.Attribute(nameof(SwitchStatementOnString), SwitchStatementOnString);
 			//sect.Attribute(nameof(UsingDeclarations), UsingDeclarations);
 			sect.Attribute(nameof(QueryExpressions), QueryExpressions);
-			//sect.Attribute(nameof(FullyQualifyAmbiguousTypeNames), FullyQualifyAmbiguousTypeNames);
-			//sect.Attribute(nameof(FullyQualifyAllTypes), FullyQualifyAllTypes);
+			sect.Attribute(nameof(FullyQualifyAmbiguousTypeNames), FullyQualifyAmbiguousTypeNames);
+			sect.Attribute(nameof(FullyQualifyAllTypes), FullyQualifyAllTypes);
 			sect.Attribute(nameof(UseDebugSymbols), UseDebugSymbols);
 			//sect.Attribute(nameof(ObjectOrCollectionInitializers), ObjectOrCollectionInitializers);
 			sect.Attribute(nameof(ShowXmlDocumentation), ShowXmlDocumentation);

--- a/Extensions/ILSpy.Decompiler/dnSpy.Decompiler.ILSpy/Themes/wpf.styles.templates.xaml
+++ b/Extensions/ILSpy.Decompiler/dnSpy.Decompiler.ILSpy/Themes/wpf.styles.templates.xaml
@@ -11,6 +11,8 @@
             <CheckBox Margin="0 5 0 0" IsChecked="{Binding Settings.QueryExpressions}" IsEnabled="{Binding Settings.AnonymousMethods}" Content="{x:Static p:dnSpy_Decompiler_ILSpy_Core_Resources.DecompilerSettings_DecompileQueryExpr}"/>
             <CheckBox Margin="0 5 0 0" IsChecked="{Binding Settings.ExpressionTrees}" Content="{x:Static p:dnSpy_Decompiler_ILSpy_Core_Resources.DecompilerSettings_DecompileExprTrees}"/>
             <CheckBox Margin="0 5 0 0" IsChecked="{Binding Settings.UseDebugSymbols}" Content="{x:Static p:dnSpy_Decompiler_ILSpy_Core_Resources.DecompilerSettings_UseLocalNameFromSyms}"/>
+            <CheckBox Margin="0 5 0 0" IsChecked="{Binding Settings.FullyQualifyAllTypes}" Content="{x:Static p:dnSpy_Decompiler_ILSpy_Core_Resources.DecompilerSettings_FullyQualifyAllTypes}"/>
+            <CheckBox Margin="0 5 0 0" IsChecked="{Binding Settings.FullyQualifyAmbiguousTypeNames}" Content="{x:Static p:dnSpy_Decompiler_ILSpy_Core_Resources.DecompilerSettings_FullyQualifyAmbiguousTypeNames}"/>
             <CheckBox Margin="0 5 0 0" IsChecked="{Binding Settings.ShowXmlDocumentation}" Content="{x:Static p:dnSpy_Decompiler_ILSpy_Core_Resources.DecompilerSettings_ShowXMLDocComments}"/>
             <CheckBox Margin="0 5 0 0" IsChecked="{Binding Settings.RemoveEmptyDefaultConstructors}" Content="{x:Static p:dnSpy_Decompiler_ILSpy_Core_Resources.DecompilerSettings_RemoveEmptyDefaultCtors}"/>
             <CheckBox Margin="0 5 0 0" IsChecked="{Binding Settings.ShowTokenAndRvaComments}" Content="{x:Static p:dnSpy_Decompiler_ILSpy_Core_Resources.DecompilerSettings_ShowTokensRvasOffsets}"/>


### PR DESCRIPTION
Added FullyQualifiedAllTypes and FullyQualifiedAbiguousTypeNames so they show in the GUI Decompiler->C# options. Related to #1117

Closes #1117