### PR TITLE
Update SatelliteAssemblyFinder.cs

### DIFF
--- a/dnSpy/dnSpy.Decompiler/MSBuild/SatelliteAssemblyFinder.cs
+++ b/dnSpy/dnSpy.Decompiler/MSBuild/SatelliteAssemblyFinder.cs
@@ -92,8 +92,10 @@ namespace dnSpy.Decompiler.MSBuild {
 
 		AssemblyDef TryOpenAssembly(string filename) {
 			lock (openedModules) {
-				if (openedModules.TryGetValue(filename, out var mod))
+				if (openedModules.TryGetValue(filename, out var mod)){
+					openedModules[filename] = mod;
 					return mod.Assembly;
+				}					
 				openedModules[filename] = null;
 				if (!File.Exists(filename))
 					return null;


### PR DESCRIPTION
openedModules[filename]  always need a value. or else it sometimes may lead to an error.