### PR TITLE
Expose UIUtilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _ReSharper*/
 *.ReSharper
 *_wpftmp.csproj
 launchSettings.json
+.idea/

--- a/dnSpy/dnSpy.Contracts.DnSpy/Utilities/UIUtilities.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Utilities/UIUtilities.cs
@@ -30,7 +30,7 @@ namespace dnSpy.Contracts.Utilities {
 	/// <summary>
 	/// UI utilities
 	/// </summary>
-	static class UIUtilities {
+	public static class UIUtilities {
 		/// <summary>
 		/// Gets the parent
 		/// </summary>


### PR DESCRIPTION
Exposes the UIUtilities class in the dnSpy.Contracts.Utilities namespace, so extensions can use it.

Closes #1201