### PR TITLE
AntiAntiDebug - IsDebuggerPresent (kernelbase.dll) bypass

### DIFF
--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/AntiAntiDebug/KernelBaseIsDebuggerPresentHook.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/AntiAntiDebug/KernelBaseIsDebuggerPresentHook.cs
@@ -1,0 +1,63 @@
+/*
+    Copyright (C) 2014-2019 de4dot@gmail.com
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using dnSpy.Contracts.Debugger;
+using dnSpy.Contracts.Debugger.AntiAntiDebug;
+
+namespace dnSpy.Debugger.AntiAntiDebug {
+	static class KernelBaseIsDebuggerPresentConstants {
+		public const string DllName = "kernelbase.dll";
+		public const string FuncName = "IsDebuggerPresent";
+	}
+
+	[ExportDbgNativeFunctionHook(KernelBaseIsDebuggerPresentConstants.DllName, KernelBaseIsDebuggerPresentConstants.FuncName, new DbgArchitecture[0], new[] { DbgOperatingSystem.Windows })]
+	sealed class KernelBaseIsDebuggerPresentHook : IDbgNativeFunctionHook {
+		readonly DebuggerSettings debuggerSettings;
+
+		[ImportingConstructor]
+		KernelBaseIsDebuggerPresentHook(DebuggerSettings debuggerSettings) => this.debuggerSettings = debuggerSettings;
+
+		public bool IsEnabled(DbgNativeFunctionHookContext context) => debuggerSettings.AntiIsDebuggerPresent;
+
+		public void Hook(DbgNativeFunctionHookContext context, out string? errorMessage) {
+			switch (context.Process.Architecture) {
+			case DbgArchitecture.X86:
+				HookX86(context, out errorMessage);
+				break;
+
+			case DbgArchitecture.X64:
+				HookX64(context, out errorMessage);
+				break;
+
+			default:
+				Debug.Fail($"Unsupported architecture: {context.Process.Architecture}");
+				errorMessage = $"Unsupported architecture: {context.Process.Architecture}";
+				break;
+			}
+		}
+
+		void HookX86(DbgNativeFunctionHookContext context, out string? errorMessage) =>
+			new KernelBaseIsDebuggerPresentPatcherX86(context).TryPatchX86(out errorMessage);
+
+		void HookX64(DbgNativeFunctionHookContext context, out string? errorMessage) =>
+			new KernelBaseIsDebuggerPresentPatcherX86(context).TryPatchX64(out errorMessage);
+	}
+}

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/AntiAntiDebug/KernelBaseIsDebuggerPresentPatcherX86.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/AntiAntiDebug/KernelBaseIsDebuggerPresentPatcherX86.cs
@@ -1,0 +1,77 @@
+/*
+    Copyright (C) 2014-2019 de4dot@gmail.com
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.Diagnostics.CodeAnalysis;
+using dnSpy.Contracts.Debugger.AntiAntiDebug;
+using Iced.Intel;
+using II = Iced.Intel;
+
+namespace dnSpy.Debugger.AntiAntiDebug {
+	sealed class KernelBaseIsDebuggerPresentPatcherX86 : PatcherX86 {
+		public KernelBaseIsDebuggerPresentPatcherX86(DbgNativeFunctionHookContext context) : base(context) { }
+
+		public bool TryPatchX86([NotNullWhen(false)] out string? errorMessage) {
+			var function = functionProvider.GetFunction(KernelBaseIsDebuggerPresentConstants.DllName, KernelBaseIsDebuggerPresentConstants.FuncName);
+
+			/*
+				Generate the following code:
+
+				xor eax,eax
+				ret
+			*/
+
+			var instructions = new InstructionList();
+			instructions.Add(Instruction.Create(II.Code.Xor_r32_rm32, Register.EAX, Register.EAX));
+			instructions.Add(Instruction.Create(II.Code.Retnd));
+
+			var block = new InstructionBlock(new CodeWriterImpl(function), instructions, function.NewCodeAddress);
+			if (!BlockEncoder.TryEncode(process.Bitness, block, out var encErrMsg)) {
+				errorMessage = $"Failed to encode: {encErrMsg}";
+				return false;
+			}
+
+			errorMessage = null;
+			return true;
+		}
+
+		public bool TryPatchX64([NotNullWhen(false)] out string? errorMessage) {
+			var function = functionProvider.GetFunction(KernelBaseIsDebuggerPresentConstants.DllName, KernelBaseIsDebuggerPresentConstants.FuncName);
+
+			/*
+				Generate the following code:
+
+				xor eax,eax
+				ret
+			*/
+
+			var instructions = new InstructionList();
+			instructions.Add(Instruction.Create(II.Code.Xor_r32_rm32, Register.EAX, Register.EAX));
+			instructions.Add(Instruction.Create(II.Code.Retnq));
+
+			var block = new InstructionBlock(new CodeWriterImpl(function), instructions, function.NewCodeAddress);
+			if (!BlockEncoder.TryEncode(process.Bitness, block, out var encErrMsg)) {
+				errorMessage = $"Failed to encode: {encErrMsg}";
+				return false;
+			}
+
+			errorMessage = null;
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes #1358 

I did not want to change too much so it's basically a copy of the IsDebuggerPresentHook classes.