### PR TITLE
Add commandline argument for additional extension directory

### DIFF
--- a/dnSpy/dnSpy.Contracts.DnSpy/App/IAppCommandLineArgs.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/App/IAppCommandLineArgs.cs
@@ -90,6 +90,9 @@ namespace dnSpy.Contracts.App {
 		/// <summary>Attach to this process name, unless it's empty. Can contain wildcards.</summary>
 		string DebugAttachProcess { get; }
 
+		/// <summary>Additional directory to check for extensions.</summary>
+		string ExtraExtensionDirectory { get; }
+
 		/// <summary>
 		/// Returns true if the argument is present
 		/// </summary>

--- a/dnSpy/dnSpy/MainApp/App.xaml.cs
+++ b/dnSpy/dnSpy/MainApp/App.xaml.cs
@@ -96,6 +96,7 @@ namespace dnSpy.MainApp {
 		Stopwatch? startupStopwatch;
 		public App(bool readSettings, Stopwatch startupStopwatch) {
 			resourceManagerTokenCacheImpl = new ResourceManagerTokenCacheImpl();
+			args = new AppCommandLineArgs();
 
 			// PERF: Init MEF on a BG thread. Results in slightly faster startup, eg. InitializeComponent() becomes a 'free' call on this UI thread
 			initializeMEFTask = Task.Run(() => InitializeMEF(readSettings, useCache: readSettings));
@@ -103,7 +104,6 @@ namespace dnSpy.MainApp {
 
 			resourceManagerTokenCacheImpl.TokensUpdated += ResourceManagerTokenCacheImpl_TokensUpdated;
 			ResourceHelper.SetResourceManagerTokenCache(resourceManagerTokenCacheImpl);
-			args = new AppCommandLineArgs();
 			AppDirectories.SetSettingsFilename(args.SettingsFilename);
 
 			AddAppContextFixes();
@@ -324,10 +324,14 @@ namespace dnSpy.MainApp {
 
 		Assembly[] LoadExtensionAssemblies() {
 			var dir = AppDirectories.BinDirectory;
+			var unsortedFiles = GetExtensionFiles(dir);
+			if (!(args.ExtraExtensionDirectory is null))
+				unsortedFiles = unsortedFiles.Concat(GetExtensionFiles(args.ExtraExtensionDirectory));
+
 			// Load the modules in a predictable order or multicore-JIT could stop recording. See
 			// "Understanding Background JIT compilation -> What can go wrong with background JIT compilation"
 			// in the PerfView docs for more info.
-			var files = GetExtensionFiles(dir).OrderBy(a => a, StringComparer.OrdinalIgnoreCase).ToArray();
+			var files = unsortedFiles.OrderBy(a => a, StringComparer.OrdinalIgnoreCase).ToArray();
 #if NETCOREAPP
 			foreach (var file in files)
 				netCoreAssemblyLoader.AddSearchPath(Path.GetDirectoryName(file)!);

--- a/dnSpy/dnSpy/MainApp/AppCommandLineArgs.cs
+++ b/dnSpy/dnSpy/MainApp/AppCommandLineArgs.cs
@@ -49,6 +49,7 @@ namespace dnSpy.MainApp {
 		public uint DebugEvent { get; }
 		public ulong JitDebugInfo { get; }
 		public string DebugAttachProcess { get; }
+		public string ExtraExtensionDirectory { get; }
 
 		readonly Dictionary<string, string> userArgs = new Dictionary<string, string>();
 		readonly List<string> filenames = new List<string>();
@@ -191,6 +192,11 @@ namespace dnSpy.MainApp {
 					case "-pn":
 					case "--process-name":
 						DebugAttachProcess = next;
+						i++;
+						break;
+
+					case "--extension-directory":
+						ExtraExtensionDirectory = GetFullPath(next);
 						i++;
 						break;
 


### PR DESCRIPTION
Uses the same `GetExtensionFiles` method as for basedir, meaning a nested `Extension` directory will also get included.

Closes #1528