### PR TITLE
Fix nullability warning

### DIFF
--- a/dnSpy/dnSpy/MainApp/App.xaml.cs
+++ b/dnSpy/dnSpy/MainApp/App.xaml.cs
@@ -325,7 +325,7 @@ namespace dnSpy.MainApp {
 		Assembly[] LoadExtensionAssemblies() {
 			var dir = AppDirectories.BinDirectory;
 			var unsortedFiles = GetExtensionFiles(dir);
-			if (!(args.ExtraExtensionDirectory is null))
+			if (!string.IsNullOrEmpty(args.ExtraExtensionDirectory))
 				unsortedFiles = unsortedFiles.Concat(GetExtensionFiles(args.ExtraExtensionDirectory));
 
 			// Load the modules in a predictable order or multicore-JIT could stop recording. See

--- a/dnSpy/dnSpy/MainApp/AppCommandLineArgs.cs
+++ b/dnSpy/dnSpy/MainApp/AppCommandLineArgs.cs
@@ -77,6 +77,7 @@ namespace dnSpy.MainApp {
 			ShowStartupTime = false;
 			DebugAttachPid = 0;
 			DebugAttachProcess = string.Empty;
+			ExtraExtensionDirectory = string.Empty;
 
 			bool canParseCommands = true;
 			for (int i = 0; i < args.Length; i++) {


### PR DESCRIPTION
Fixes a nullability warning I accidentally introduced with #1530. I didn't notice it at first because my IDE doesn't seem to show them.

Made it an empty string by default instead of annotating the property as nullable so it matches the other properties.