### PR TITLE
Don't force focus change after rename if renamed node was not selected

### DIFF
--- a/Extensions/dnSpy.AsmEditor/Assembly/AssemblyCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Assembly/AssemblyCommands.cs
@@ -337,7 +337,6 @@ namespace dnSpy.AsmEditor.Assembly {
 						info.AssemblyRef.PublicKeyOrToken = newOptions.PublicKey;
 				}
 			}
-			asmNode.TreeNode.TreeView.SelectItems(new[] { asmNode });
 			asmNode.TreeNode.RefreshUI();
 		}
 

--- a/Extensions/dnSpy.AsmEditor/Event/EventDefCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Event/EventDefCommands.cs
@@ -414,11 +414,15 @@ namespace dnSpy.AsmEditor.Event {
 				Debug.Assert(b);
 				if (!b)
 					throw new InvalidOperationException();
+
+				var isNodeSelected = eventNode.TreeNode.TreeView.SelectedItem == eventNode;
+
 				origParentNode.TreeNode.Children.RemoveAt(origParentChildIndex);
 				newOptions.CopyTo(eventNode.EventDef);
-
 				origParentNode.TreeNode.AddChild(eventNode.TreeNode);
-				origParentNode.TreeNode.TreeView.SelectItems(new[] { eventNode });
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { eventNode });
 			}
 			else
 				newOptions.CopyTo(eventNode.EventDef);

--- a/Extensions/dnSpy.AsmEditor/Field/FieldDefCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Field/FieldDefCommands.cs
@@ -424,11 +424,15 @@ namespace dnSpy.AsmEditor.Field {
 				Debug.Assert(b);
 				if (!b)
 					throw new InvalidOperationException();
+
+				var isNodeSelected = fieldNode.TreeNode.TreeView.SelectedItem == fieldNode;
+
 				origParentNode.TreeNode.Children.RemoveAt(origParentChildIndex);
 				newOptions.CopyTo(fieldNode.FieldDef);
-
 				origParentNode.TreeNode.AddChild(fieldNode.TreeNode);
-				origParentNode.TreeNode.TreeView.SelectItems(new[] { fieldNode });
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { fieldNode });
 			}
 			else
 				newOptions.CopyTo(fieldNode.FieldDef);

--- a/Extensions/dnSpy.AsmEditor/Method/MethodDefCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Method/MethodDefCommands.cs
@@ -512,11 +512,15 @@ namespace dnSpy.AsmEditor.Method {
 				Debug.Assert(b);
 				if (!b)
 					throw new InvalidOperationException();
+
+				var isNodeSelected = methodNode.TreeNode.TreeView.SelectedItem == methodNode;
+
 				origParentNode.TreeNode.Children.RemoveAt(origParentChildIndex);
 				newOptions.CopyTo(methodNode.MethodDef);
-
 				origParentNode.TreeNode.AddChild(methodNode.TreeNode);
-				origParentNode.TreeNode.TreeView.SelectItems(new[] { methodNode });
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { methodNode });
 			}
 			else
 				newOptions.CopyTo(methodNode.MethodDef);

--- a/Extensions/dnSpy.AsmEditor/Module/ModuleCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Module/ModuleCommands.cs
@@ -766,7 +766,6 @@ namespace dnSpy.AsmEditor.Module {
 
 		void WriteModuleOptions(ModuleOptions theOptions) {
 			theOptions.CopyTo(modNode.Document.ModuleDef!);
-			modNode.TreeNode.TreeView.SelectItems(new[] { modNode });
 			modNode.TreeNode.RefreshUI();
 		}
 

--- a/Extensions/dnSpy.AsmEditor/Namespace/NamespaceCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Namespace/NamespaceCommands.cs
@@ -450,6 +450,9 @@ namespace dnSpy.AsmEditor.Namespace {
 				Debug.Assert(b);
 				if (!b)
 					throw new InvalidOperationException();
+
+				var isNodeSelected = nsNode.TreeNode.TreeView.SelectedItem == nsNode;
+
 				origParentNode.TreeNode.Children.RemoveAt(origParentChildIndex);
 				nsNode.Name = newName;
 
@@ -457,7 +460,10 @@ namespace dnSpy.AsmEditor.Namespace {
 					typeNode.TypeDef.Namespace = newNamespace;
 
 				origParentNode.TreeNode.AddChild(nsNode.TreeNode);
-				origParentNode.TreeNode.TreeView.SelectItems(new[] { nsNode });
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { nsNode });
+
 				nsNode.TreeNode.RefreshUI();
 			}
 
@@ -481,6 +487,8 @@ namespace dnSpy.AsmEditor.Namespace {
 				}
 			}
 			else {
+				var isNodeSelected = nsNode.TreeNode.TreeView.SelectedItem == nsNode;
+
 				bool b = origParentNode.TreeNode.Children.Remove(nsNode.TreeNode);
 				Debug.Assert(b);
 				if (!b)
@@ -491,7 +499,10 @@ namespace dnSpy.AsmEditor.Namespace {
 
 				nsNode.Name = origName;
 				origParentNode.TreeNode.Children.Insert(origParentChildIndex, nsNode.TreeNode);
-				origParentNode.TreeNode.TreeView.SelectItems(new[] { nsNode });
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { nsNode });
+
 				nsNode.TreeNode.RefreshUI();
 			}
 

--- a/Extensions/dnSpy.AsmEditor/Property/PropertyDefCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Property/PropertyDefCommands.cs
@@ -411,11 +411,15 @@ namespace dnSpy.AsmEditor.Property {
 				Debug.Assert(b);
 				if (!b)
 					throw new InvalidOperationException();
+
+				var isNodeSelected = propNode.TreeNode.TreeView.SelectedItem == propNode;
+
 				origParentNode.TreeNode.Children.RemoveAt(origParentChildIndex);
 				newOptions.CopyTo(propNode.PropertyDef);
-
 				origParentNode.TreeNode.AddChild(propNode.TreeNode);
-				origParentNode.TreeNode.TreeView.SelectItems(new[] { propNode });
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { propNode });
 			}
 			else
 				newOptions.CopyTo(propNode.PropertyDef);
@@ -424,6 +428,8 @@ namespace dnSpy.AsmEditor.Property {
 
 		public void Undo() {
 			if (nameChanged) {
+				var isNodeSelected = propNode.TreeNode.TreeView.SelectedItem == propNode;
+
 				bool b = origParentNode.TreeNode.Children.Remove(propNode.TreeNode);
 				Debug.Assert(b);
 				if (!b)
@@ -431,7 +437,9 @@ namespace dnSpy.AsmEditor.Property {
 
 				origOptions.CopyTo(propNode.PropertyDef);
 				origParentNode.TreeNode.Children.Insert(origParentChildIndex, propNode.TreeNode);
-				origParentNode.TreeNode.TreeView.SelectItems(new[] { propNode });
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { propNode });
 			}
 			else
 				origOptions.CopyTo(propNode.PropertyDef);

--- a/Extensions/dnSpy.AsmEditor/Resources/ResourceCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Resources/ResourceCommands.cs
@@ -1075,11 +1075,15 @@ namespace dnSpy.AsmEditor.Resources {
 				Debug.Assert(b);
 				if (!b)
 					throw new InvalidOperationException();
+
+				var isNodeSelected = rsrcNode.Node.TreeNode.TreeView.SelectedItem == rsrcNode.Node;
+
 				origParentNode.TreeNode.Children.RemoveAt(origParentChildIndex);
 				newOptions.CopyTo(rsrcNode.Resource);
-
 				origParentNode.TreeNode.AddChild(rsrcNode.Node.TreeNode);
-				origParentNode.TreeNode.TreeView.SelectItems(new[] { rsrcNode.Node });
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { rsrcNode.Node });
 			}
 			else
 				newOptions.CopyTo(rsrcNode.Resource);
@@ -1088,6 +1092,8 @@ namespace dnSpy.AsmEditor.Resources {
 
 		public void Undo() {
 			if (nameChanged) {
+				var isNodeSelected = rsrcNode.Node.TreeNode.TreeView.SelectedItem == rsrcNode.Node;
+
 				bool b = origParentNode.TreeNode.Children.Remove(rsrcNode.Node.TreeNode);
 				Debug.Assert(b);
 				if (!b)
@@ -1095,7 +1101,9 @@ namespace dnSpy.AsmEditor.Resources {
 
 				origOptions.CopyTo(rsrcNode.Resource);
 				origParentNode.TreeNode.Children.Insert(origParentChildIndex, rsrcNode.Node.TreeNode);
-				origParentNode.TreeNode.TreeView.SelectItems(new[] { rsrcNode.Node });
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { rsrcNode.Node });
 			}
 			else
 				origOptions.CopyTo(rsrcNode.Resource);

--- a/Extensions/dnSpy.AsmEditor/Types/TypeDefCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Types/TypeDefCommands.cs
@@ -530,22 +530,32 @@ namespace dnSpy.AsmEditor.Types {
 				Debug.Assert(b);
 				if (!b)
 					throw new InvalidOperationException();
+
+				var isNodeSelected = typeNode.TreeNode.TreeView.SelectedItem == typeNode;
+
 				origParentNode.TreeNode.Children.RemoveAt(origParentChildIndex);
 				newOptions.CopyTo(typeNode.TypeDef, module);
 
 				nsNodeCreator.Add();
 				nsNodeCreator.NamespaceNode.TreeNode.AddChild(typeNode.TreeNode);
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { typeNode });
 			}
 			else if (nameChanged) {
 				bool b = origParentChildIndex < origParentNode.TreeNode.Children.Count && origParentNode.TreeNode.Children[origParentChildIndex] == typeNode.TreeNode;
 				Debug.Assert(b);
 				if (!b)
 					throw new InvalidOperationException();
+
+				var isNodeSelected = typeNode.TreeNode.TreeView.SelectedItem == typeNode;
+
 				origParentNode.TreeNode.Children.RemoveAt(origParentChildIndex);
 				newOptions.CopyTo(typeNode.TypeDef, module);
-
 				origParentNode.TreeNode.AddChild(typeNode.TreeNode);
-				origParentNode.TreeNode.TreeView.SelectItems(new[] { typeNode });
+
+				if (isNodeSelected)
+					origParentNode.TreeNode.TreeView.SelectItems(new[] { typeNode });
 			}
 			else
 				newOptions.CopyTo(typeNode.TypeDef, module);


### PR DESCRIPTION
This PR changes the behavior from #559 to only happen when the renamed node is selected. This stops dnSpy from focusing a MethodDef node when renaming a method from a TypeDef node, for example.

Undo behavior is unchanged, meaning that undo will still focus the MethodDef node even if its parent TypeDef node was selected.